### PR TITLE
Addresses the edge case where a post has no title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this theme will be documented in this file. The format is
 - Migrated `@import` SCSS rules to `@use`
 - Consolidated `_customize-cpt.scss` styles into `cpt.scss`
 - Addresses the edge case where a post or page has no title:
+  - Doesn't output the title container if there is no title or thumbnail
   - Makes the post date in the byline into a link to the post
   - Uses an excerpt of the post content for the breadcrumb label and `<title>` tag
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ All notable changes to this theme will be documented in this file. The format is
 
 ### Added
 - Max-width utility classes corresponding to breakpoints
+- `has_post_header()` and `has_post_title()` utility functions in `/frontend/frontend.php`
 
 ### Changed
 - Migrated `@import` SCSS rules to `@use`
 - Consolidated `_customize-cpt.scss` styles into `cpt.scss`
+- Addresses the edge case where a post or page has no title:
+  - Makes the post date in the byline into a link to the post
+  - Uses an excerpt of the post content for the breadcrumb label and `<title>` tag
 
 ### Removed
 - Now that WordPress adds global padding/layout classes to the admin editor, the `/assets/js/admin-editor-classes.js` script is no longer necessary

--- a/frontend/breadcrumbs.php
+++ b/frontend/breadcrumbs.php
@@ -33,8 +33,9 @@ function breadcrumbs( $separator = '/' ) {
 		if ( has_post_title() ) {
 			$label = get_the_title();
 		} else {
-			$label .= wp_trim_words( wp_strip_all_tags( get_the_content() ), 15, '…' );
+			$label = wp_trim_words( wp_strip_all_tags( get_the_content() ), 15, '…' );
 		}
+
 		if ( get_query_var( 'page' ) ) {
 			$label .= ' (' . $page_label . ' ' . get_query_var( 'page' ) . ')';
 		}

--- a/frontend/breadcrumbs.php
+++ b/frontend/breadcrumbs.php
@@ -30,7 +30,11 @@ function breadcrumbs( $separator = '/' ) {
 			$label .= ' (' . $page_label . ' ' . get_query_var( 'paged' ) . ')';
 		}
 	} elseif ( is_singular() ) {
-		$label = get_the_title();
+		if ( has_post_title() ) {
+			$label = get_the_title();
+		} else {
+			$label .= wp_trim_words( wp_strip_all_tags( get_the_content() ), 15, '…' );
+		}
 		if ( get_query_var( 'page' ) ) {
 			$label .= ' (' . $page_label . ' ' . get_query_var( 'page' ) . ')';
 		}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -43,7 +43,7 @@ function read_more_link() {
  * @return bool
  */
 function has_post_title() {
-	if ( ! in_the_loop() ) {
+	if ( ! is_singular() ) {
 		return;
 	}
 
@@ -59,7 +59,7 @@ function has_post_title() {
  * @return bool
  */
 function has_post_header() {
-	if ( ! in_the_loop() ) {
+	if ( ! is_singular() ) {
 		return;
 	}
 
@@ -68,4 +68,15 @@ function has_post_header() {
 	}
 
 	return false;
+}
+
+// add_filter( 'pre_get_document_title', 'cpt_no_title_tag' );
+function cpt_no_title_tag( $title ) {
+	if ( current_action() !== 'wp_head' ) {
+		return $title;
+	}
+	if ( ! is_singular() || ! empty( $title ) ) {
+		return $title;
+	}
+	return wp_trim_words( wp_strip_all_tags( get_the_content() ), 15, '…' );
 }

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -70,13 +70,21 @@ function has_post_header() {
 	return false;
 }
 
-// add_filter( 'pre_get_document_title', 'cpt_no_title_tag' );
-function cpt_no_title_tag( $title ) {
-	if ( current_action() !== 'wp_head' ) {
+add_filter( 'pre_get_document_title', 'cpt_no_title_title_tag' );
+/**
+ * Uses the first 15 words of the content for the `title` tag if there is no post title.
+ *
+ * @param string $title The post title.
+ * @return string
+ */
+function cpt_no_title_title_tag( $title ) {
+	if (
+		! doing_action( 'wp_head' ) ||
+		! is_singular() ||
+		has_post_title()
+	) {
 		return $title;
 	}
-	if ( ! is_singular() || ! empty( $title ) ) {
-		return $title;
-	}
+
 	return wp_trim_words( wp_strip_all_tags( get_the_content() ), 15, '…' );
 }

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -35,3 +35,37 @@ function read_more_link() {
 	<?php
 	return ob_get_clean();
 }
+
+
+/**
+ * Checks to see if the post has a title. Must be used in the loop.
+ *
+ * @return bool
+ */
+function has_post_title() {
+	if ( ! in_the_loop() ) {
+		return;
+	}
+
+	if ( ! empty( get_the_title() ) ) {
+		return true;
+	}
+
+	return false;
+}
+/**
+ * Checks to see if the post has a title or thumnail. Must be used in the loop.
+ *
+ * @return bool
+ */
+function has_post_header() {
+	if ( ! in_the_loop() ) {
+		return;
+	}
+
+	if ( has_post_title() || has_post_thumbnail() ) {
+		return true;
+	}
+
+	return false;
+}

--- a/template-parts/loop-index.php
+++ b/template-parts/loop-index.php
@@ -10,6 +10,8 @@
 
 ?>
 
+<?php $has_post_title = has_post_title(); ?>
+
 <article id="post-<?php echo esc_attr( get_the_ID() ); ?>" <?php post_class(); ?>>
 	<?php if ( has_post_thumbnail() ) { ?>
 		<a 
@@ -21,17 +23,19 @@
 		</a>
 	<?php } ?>
 	<div class="title-excerpt-footer__container">
-		<header class="entry-header has-global-padding is-layout-constrained">
-			<h2 class="post-title wp-block-post-title is-layout-constrained">
-				<a 
+		<?php if ( $has_post_title ) { ?>
+			<header class="entry-header has-global-padding is-layout-constrained">
+				<h2 class="post-title wp-block-post-title is-layout-constrained">
+					<a 
 					href="<?php the_permalink(); ?>" 
 					rel="bookmark" 
 					title="<?php the_title(); ?>"
-				>
-					<?php the_title(); ?>
-				</a>
-			</h2>
-		</header>
+					>
+						<?php the_title(); ?>
+					</a>
+				</h2>
+			</header>
+		<?php } ?>
 		<div class="entry-content entry-excerpt wp-block-post-content has-global-padding is-layout-constrained">
 			<p class="excerpt"><?php echo wp_kses_post( get_the_excerpt() ); ?></p>
 			<div class="clearfix"></div>
@@ -40,11 +44,15 @@
 			<?php $comment_count = get_comment_count( get_the_ID() )['approved']; ?>
 			<p class="entry-byline">
 				<?php
+				$date = get_the_date( 'F jS, Y' );
+				if ( ! has_post_title() ) {
+					$date = '<a href="' . esc_url( get_the_permalink() ) . '">' . $date . '</a>';
+				}
+				// Translators: %1$s is the author's display name. %2$s is the publication date.
 				printf(
-					// Translators: %1$s is the author's display name. %2$s is the publication date.
-					esc_html__( 'By %1$s on %2$s.', 'cpt-theme' ),
+					'By %1$s on %2$s.',
 					/* $1%s */ esc_html( get_the_author_meta( 'display_name' ) ),
-					/* $2%s */ esc_html( get_the_date( 'F jS, Y' ) ),
+					/* $2%s */ wp_kses_post( $date ),
 				);
 				?>
 				<?php if ( $comment_count ) { ?>

--- a/template-parts/loop-page.php
+++ b/template-parts/loop-page.php
@@ -13,14 +13,14 @@
 <article id="content" <?php post_class(); ?>>
 	<?php
 	$blocks         = parse_blocks( $post->post_content );
-	$header_classes = 'page-header has-global-padding is-layout-constrained';
+	$page_header_classes = 'page-header has-global-padding is-layout-constrained';
 
 	if ( is_front_page() ) {
-		$header_classes .= ' screen-reader-text';
+		$page_header_classes .= ' screen-reader-text';
 	}
 
 	if ( has_post_thumbnail() ) {
-		$header_classes .= ' has-background-image alignfull';
+		$page_header_classes .= ' has-background-image alignfull';
 	}
 
 	if (
@@ -39,7 +39,7 @@
 	) {
 		?>
 		<header 
-			class="<?php echo esc_attr( $header_classes ); ?>"
+			class="<?php echo esc_attr( $page_header_classes ); ?>"
 			<?php if ( has_post_thumbnail() ) { ?>
 				style="background-image: url('<?php echo esc_url( wp_get_attachment_image_url( get_post_thumbnail_id(), 'full' ) ); ?>');"
 			<?php } ?>

--- a/template-parts/loop-page.php
+++ b/template-parts/loop-page.php
@@ -10,9 +10,11 @@
 
 ?>
 
+<?php $has_page_header = has_post_header(); ?>
+
 <article id="content" <?php post_class(); ?>>
 	<?php
-	$blocks         = parse_blocks( $post->post_content );
+	$blocks              = parse_blocks( $post->post_content );
 	$page_header_classes = 'page-header has-global-padding is-layout-constrained';
 
 	if ( is_front_page() ) {
@@ -24,7 +26,8 @@
 	}
 
 	if (
-		! $blocks || (
+		(
+			! $blocks || (
 			$blocks && (
 				( 'core/cover' !== $blocks[0]['blockName'] )
 				&& (
@@ -35,7 +38,9 @@
 					)
 				)
 			)
-		)
+			)
+		) &&
+		$has_page_header
 	) {
 		?>
 		<header 

--- a/template-parts/loop-single.php
+++ b/template-parts/loop-single.php
@@ -10,15 +10,24 @@
 
 ?>
 
+<?php
+$has_post_header = has_post_header();
+$has_post_title  = has_post_title();
+?>
+
 <article id="content" <?php post_class(); ?>>
-	<header class="page-header has-global-padding is-layout-constrained">
-		<?php
-		the_title( '<h1 class="entry-title wp-block-post-title">', '</h1>' );
-		if ( has_post_thumbnail() ) {
-			the_post_thumbnail();
-		}
-		?>
-	</header>
+	<?php if ( $has_post_header ) { ?>
+		<header class="page-header has-global-padding is-layout-constrained">
+			<?php
+			if ( $has_post_title ) {
+				the_title( '<h1 class="entry-title wp-block-post-title">', '</h1>' );
+			}
+			if ( has_post_thumbnail() ) {
+				the_post_thumbnail();
+			}
+			?>
+		</header>
+	<?php } ?>
 	<div class="entry-content wp-block-post-content has-global-padding is-layout-constrained">
 		<?php the_content(); ?>
 		<div class="clearfix"></div>

--- a/template-parts/site-header.php
+++ b/template-parts/site-header.php
@@ -8,11 +8,11 @@
  * @since      1.2.0
  */
 
-$header_classes  = 'site-header';
-$header_classes .= get_theme_mod( 'custom_logo' ) ? ' has-custom-logo' : '';
-$header_classes .= get_option( 'cpt_sites_show_preheader' ) ? ' show-preheader' : '';
-$header_classes .= get_option( 'cpt_sites_show_primary_menu' ) ? ' show-primary-menu' : '';
-$header_classes .= get_option( 'cpt_sites_show_primary_menu_cta' ) ? ' show-header-cta' : '';
+$site_header_classes  = 'site-header';
+$site_header_classes .= get_theme_mod( 'custom_logo' ) ? ' has-custom-logo' : '';
+$site_header_classes .= get_option( 'cpt_sites_show_preheader' ) ? ' show-preheader' : '';
+$site_header_classes .= get_option( 'cpt_sites_show_primary_menu' ) ? ' show-primary-menu' : '';
+$site_header_classes .= get_option( 'cpt_sites_show_primary_menu_cta' ) ? ' show-header-cta' : '';
 
 $site_title       = get_bloginfo( 'name' );
 $site_title_tag   = is_front_page() ? 'h1' : 'p';
@@ -25,7 +25,7 @@ $show_primary_menu = get_option( 'cpt_sites_show_primary_menu' );
 $show_cta          = get_option( 'cpt_sites_show_primary_menu_cta' );
 ?>
 
-<header class="<?php echo esc_attr( $header_classes ); ?>">
+<header class="<?php echo esc_attr( $site_header_classes ); ?>">
 	<?php if ( get_option( 'cpt_sites_show_preheader' ) ) { ?>
 		<div class="site-preheader wp-block-group alignfull has-global-padding is-layout-constrained">
 			<div class="site-preheader__inner wp-block-group alignwide">


### PR DESCRIPTION
- Doesn't output the title container if there is no title or thumbnail
- Makes the post date in the byline into a link to the post
- Uses an excerpt of the post content for the breadcrumb label and `<title>` tag

Closes #25